### PR TITLE
Fixes #25

### DIFF
--- a/ics/icalendar.py
+++ b/ics/icalendar.py
@@ -26,7 +26,7 @@ class Calendar(Component):
     _EXTRACTORS = []
     _OUTPUTS = []
 
-    def __init__(self, imports=None, events=EventList(), creator=None):
+    def __init__(self, imports=None, events=None, creator=None):
         '''Instanciates a new Calendar.
         Optional arguments:
             - imports (string or list of lines/strings): data to be imported into the Calendar()
@@ -40,6 +40,9 @@ class Calendar(Component):
         self._unused = Container(name='VCALENDAR')
         self.scale = None
         self.method = None
+
+        if events is None:
+            events = EventList()
 
         if imports is not None:
             if isinstance(imports, text_type):


### PR DESCRIPTION
Now it is possible to use two different calendars:

```
In [1]: from ics import Calendar, Event

In [2]: c = Calendar()

In [3]: e = Event()

In [4]: e.name = "test"

In [5]: e.begin = "2013-11-04T08:15:00+00:00"

In [6]: c.events.append(e)

In [7]: c.events
Out[7]: [<Event 'test' begin:2013-11-04T08:15:00+00:00 end:2013-11-04T08:15:01+00:00>]

In [8]: d = Calendar()

In [9]: d.events
Out[9]: []

In [10]: c.events
Out[10]: [<Event 'test' begin:2013-11-04T08:15:00+00:00 end:2013-11-04T08:15:01+00:00>]

In [11]: c = Calendar()

In [12]: c.events
Out[12]: []
```
