### PR TITLE
Fix plural form of events and todos

### DIFF
--- a/src/ics/icalendar.py
+++ b/src/ics/icalendar.py
@@ -124,9 +124,9 @@ class Calendar(CalendarAttrs):
     def __str__(self) -> str:
         return "<Calendar with {} event{} and {} todo{}>".format(
             len(self.events),
-            "s" if len(self.events) > 1 else "",
+            "" if len(self.events) == 1 else "s",
             len(self.todos),
-            "s" if len(self.todos) > 1 else "")
+            "" if len(self.todos) == 1 else "s")
 
     def __iter__(self) -> Iterator[str]:
         """Returns:


### PR DESCRIPTION
Greetings! Big fan, small fix. Read the guidelines, don't think this warrants opening an issue, but do let me know if you need a test for this.

Fixes `<Calendar with 0 event and 0 todo>` [sic]