### PR TITLE
Include ics.py version in PRODID field

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -11,7 +11,11 @@ serialize =
 
 [bumpversion:file:src/ics/__init__.py]
 
+[bumpversion:file:src/ics/icalendar.py]
+
 [bumpversion:file:doc/event.rst]
+
+[bumpversion:file:doc/timezone.rst]
 
 [bumpversion:file:doc/conf.py]
 

--- a/doc/timezone.rst
+++ b/doc/timezone.rst
@@ -56,7 +56,7 @@ Now let's see what happens when we use a real timezone, e.g. the Olson timezone 
     >>> print(Calendar(events=[e]).serialize())  # doctest: +ELLIPSIS,+NORMALIZE_WHITESPACE
     BEGIN:VCALENDAR
     VERSION:2.0
-    PRODID:ics.py - http://git.io/lLljaA
+    PRODID:ics.py 0.8.0-dev - http://git.io/lLljaA
     BEGIN:VTIMEZONE
     TZID:/ics.py/2020.1/America/New_York
     ...

--- a/src/ics/icalendar.py
+++ b/src/ics/icalendar.py
@@ -38,7 +38,7 @@ class Calendar(CalendarAttrs):
 
     NAME = "VCALENDAR"
     DEFAULT_VERSION: ClassVar[str] = "2.0"
-    DEFAULT_PRODID: ClassVar[str] = "ics.py - http://git.io/lLljaA"
+    DEFAULT_PRODID: ClassVar[str] = "ics.py 0.8.0-dev - http://git.io/lLljaA"
 
     def __init__(
             self,

--- a/tests/issues/gh251.py
+++ b/tests/issues/gh251.py
@@ -1,13 +1,13 @@
 from datetime import datetime, timedelta
 
-from ics import Calendar, Event
+from ics import Calendar, Event, __version__
 from ics.event import deterministic_event_data, default_uid_factory, default_dtstamp_factory
 from ics.timezone import UTC
 
 CALENDAR = """
 BEGIN:VCALENDAR
 VERSION:2.0
-PRODID:ics.py - http://git.io/lLljaA
+PRODID:ics.py {version} - http://git.io/lLljaA
 BEGIN:VEVENT
 DTSTART:20000201T120000
 SUMMARY:second
@@ -61,7 +61,7 @@ def test_deterministic_events_deco():
     cal = make_calendar()
     uid = default_uid_factory.get()()
     dtstamp = default_dtstamp_factory.get()().strftime("%Y%m%dT%H%M%SZ")
-    assert cal.serialize().strip() == CALENDAR.format(uid=uid, dtstamp=dtstamp)
+    assert cal.serialize().strip() == CALENDAR.format(uid=uid, dtstamp=dtstamp, version=__version__)
 
     assert cal == make_calendar()
     assert cal.serialize() == make_calendar().serialize()
@@ -80,7 +80,7 @@ def test_deterministic_events_cm():
 
     cal3 = make_calendar()
 
-    assert cal1.serialize().strip() == CALENDAR.format(uid=uid, dtstamp=dtstamp)
+    assert cal1.serialize().strip() == CALENDAR.format(uid=uid, dtstamp=dtstamp, version=__version__)
 
     assert cal1.serialize() == cal2.serialize()
     assert cal1 == cal2
@@ -102,6 +102,6 @@ def test_deterministic_events_cm_params():
         assert uid == default_uid_factory.get()()
         assert dtstamp == default_dtstamp_factory.get()().strftime("%Y%m%dT%H%M%SZ")
 
-    assert cal.serialize().strip() == CALENDAR.format(uid=uid, dtstamp=dtstamp)
+    assert cal.serialize().strip() == CALENDAR.format(uid=uid, dtstamp=dtstamp, version=__version__)
     assert uid != default_uid_factory.get()()
     assert dtstamp != default_dtstamp_factory.get()().strftime("%Y%m%dT%H%M%SZ")


### PR DESCRIPTION
This PR will include the version of ics.py in the PRODID field, which currently defaults to `ics.py - http://git.io/lLljaA`, so that an empty calendar will now look like this:
```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:ics.py 0.8.0-dev - http://git.io/lLljaA
END:VCALENDAR
```
This should help with identifying the affected versions of bug reports. One could also include further system information for debugging such as the python interpreter and version and the OS, although this might be a problem with privacy (and possibly security, if we report a vulnerable version). Furthermore, including more information in the PRODID also makes deterministic outputs harder to get, e.g. see the updated bumpversion config. So I'm not 100% sure we should do this at all, but using only the version might be a good compromise between debugging information and reproducability.