### PR TITLE
Add experimental testing for Python 3.11

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,15 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7", "pypy-3.8"]
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "pypy-3.7"
+          - "pypy-3.8"
+          # Test future versions to detect bugs early
+          - "3.11.0-alpha.3"
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,9 +6,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
-      max-parallel: 5
       matrix:
+        experimental: [false]
         python-version:
           - "3.7"
           - "3.8"
@@ -16,8 +17,9 @@ jobs:
           - "3.10"
           - "pypy-3.7"
           - "pypy-3.8"
-          # Test future versions to detect bugs early
-          - "3.11.0-alpha.3"
+        include:
+        - python-version: "3.11.0-alpha.3"
+          experimental: true
 
     steps:
     - uses: actions/checkout@master

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py37, py38, py39, py310, pypy37, pypy38, checks, docs
+envlist = py37, py38, py39, py310, pypy37, pypy38, checks, docs, py311
 
 [testenv]
 description = Run the pytest suite
@@ -54,8 +54,10 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310, checks, docs
+    3.11: py311
     pypy-3.7: pypy37
     pypy-3.8: pypy38
+
 
 [pytest]
 python_files = *.py


### PR DESCRIPTION
It's always nice to test on alpha or beta versions of Python, either to help find bugs in the new version or to catch incompatibilities with a new version in time.
This also configures Github Actions to allow the 3.11 step without failing the rest of the builds.