### PR TITLE
ENH: add support for calendar name

### DIFF
--- a/src/ics/converter/types/calendar.py
+++ b/src/ics/converter/types/calendar.py
@@ -19,7 +19,8 @@ class CalendarMeta(ComponentMeta):
 
     def find_converters(self):
         return sort_converters(itertools.chain(
-            super(CalendarMeta, self).find_converters(), (CalendarTimezoneConverter(),)
+            super(CalendarMeta, self).find_converters(),
+                (CalendarTimezoneConverter(), CalendarNameConverter())
         ))
 
     def _populate_attrs(self, instance: Component, container: Container, context: ContextDict):
@@ -60,6 +61,26 @@ class CalendarTimezoneConverter(GenericConverter):
     def serialize(self, component: Component, output: Container, context: ContextDict):
         # store the place where we should insert all the timezones
         context["VTIMEZONES_AFTER"] = len(output)
+
+
+class CalendarNameConverter(GenericConverter):
+    @property
+    def priority(self) -> int:
+        return 1100
+
+    @property
+    def filter_ics_names(self) -> List[str]:
+        return ["NAME", "X-WR-CALNAME"]
+
+    def populate(self, component: Component, item: ContainerItem, context: ContextDict) -> bool:
+        if item.name == "NAME":
+            return True
+        if item.name == "X-WR-CALNAME":
+            component.name = item.value
+            return False
+
+    def serialize(self, component: Component, output: Container, context: ContextDict):
+        pass
 
 
 ComponentMeta.BY_TYPE[Calendar] = CalendarMeta(Calendar)

--- a/src/ics/icalendar.py
+++ b/src/ics/icalendar.py
@@ -14,6 +14,7 @@ from ics.todo import Todo
 
 @attr.s
 class CalendarAttrs(Component):
+    name: str = attr.ib(validator=instance_of(str), metadata={"ics_priority": 1100})
     version: str = attr.ib(validator=instance_of(str), metadata={"ics_priority": 1000})  # default set by Calendar.DEFAULT_VERSION
     prodid: str = attr.ib(validator=instance_of(str), metadata={"ics_priority": 900})  # default set by Calendar.DEFAULT_PRODID
     scale: Optional[str] = attr.ib(default=None, metadata={"ics_priority": 800})
@@ -37,6 +38,7 @@ class Calendar(CalendarAttrs):
     """
 
     NAME = "VCALENDAR"
+    DEFAULT_CALNAME = "Calendar"
     DEFAULT_VERSION: ClassVar[str] = "2.0"
     DEFAULT_PRODID: ClassVar[str] = "ics.py 0.8.0-dev - http://git.io/lLljaA"
 
@@ -60,6 +62,7 @@ class Calendar(CalendarAttrs):
             events = tuple()
         if todos is None:
             todos = tuple()
+        kwargs.setdefault("name", self.DEFAULT_CALNAME)
         kwargs.setdefault("version", self.DEFAULT_VERSION)
         kwargs.setdefault("prodid", creator if creator is not None else self.DEFAULT_PRODID)
         super(Calendar, self).__init__(events=events, todos=todos, **kwargs)  # type: ignore[arg-type]

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,18 @@
+from ics import Calendar
+
+lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Apple Inc.//Mac OS X 10.13.5//EN",
+    "CALSCALE:GREGORIAN",
+    "BEGIN:VEVENT",
+    r"DESCRIPTION:Title: My event",
+    "END:VEVENT",
+    "END:VCALENDAR",
+]
+
+
+def test_cal_name():
+    calendar = Calendar(lines)
+
+    assert calendar.name == Calendar.DEFAULT_CALNAME


### PR DESCRIPTION
Closes #307

* Add `NAME` and `X-WR-CALNAME` support.
* `X-WR-CALNAME` is converted to `NAME` and `X-WR-CALNAME` is added in extras.
* Default name is used when the field is not present.
