### PR TITLE
add warnings about breaking changes to Calendar.__str__ and __iter__ in v0.7(.1)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Quickstart
     c.events
     # [<Event 'My cool event' begin:2014-01-01 00:00:00 end:2014-01-01 00:00:01>]
     with open('my.ics', 'w') as my_file:
-        my_file.writelines(c)
+        my_file.writelines(c.serialize_iter())
     # and it's done !
 
 More examples are available in the

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -42,9 +42,9 @@ Export a Calendar to a file
 .. code-block:: python
 
     with open('my.ics', 'w') as f:
-        f.writelines(c)
+        f.writelines(c.serialize_iter())
     # And it's done !
 
     # iCalendar-formatted data is also available in a string
-    str(c)
+    c.serialize()
     # 'BEGIN:VCALENDAR\nPRODID:...

--- a/ics/component.py
+++ b/ics/component.py
@@ -1,6 +1,6 @@
 import warnings
 from collections import namedtuple
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, Iterable
 
 from ics.grammar.parse import Container
 from .utils import get_lines
@@ -65,9 +65,25 @@ class Component(object):
 
         self.extra = container  # Store unused lines
 
-    def __str__(self) -> str:
+    def serialize(self) -> str:
         """Returns the component in an iCalendar format."""
         container = self.extra.clone()
         for output in self.Meta.serializer.get_serializers():
             output(self, container)
         return str(container)
+
+    def serialize_iter(self) -> Iterable[str]:
+        """Returns the component in an iCalendar format.
+
+        This returns an Iterable of multiple string chunks which should be concatenated to form the actual ics representation.
+        Note that individual items of the returned Iterable not necessarily correspond to individual lines,
+        linebreaks are contained at the right places within the items."""
+        return self.serialize().splitlines(keepends=True)
+
+    def __str__(self) -> str:
+        """Starting from version 0.9, returns a short description of the Component."""
+        warnings.warn(
+            "Behaviour of str(Component) will change in version 0.9 to only return a short description, NOT the ics representation. "
+            "Use the explicit Component.serialize() to get the ics representation.", FutureWarning
+        )
+        return self.serialize()

--- a/ics/icalendar.py
+++ b/ics/icalendar.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 from typing import Dict, Iterable, Optional, Set, Union
 
 from six import text_type
@@ -100,8 +101,10 @@ class Calendar(Component):
             >>> c = Calendar(); c.events.add(Event(name="My cool event"))
             >>> open('my.ics', 'w').writelines(c)
         """
-        for line in str(self).split('\n'):
-            yield line + '\n'
+        warnings.warn(
+            "Using Calendar as Iterable is deprecated and will be removed in version 0.8. "
+            "Use the explicit calendar.serialize_iter() instead.", DeprecationWarning)
+        return self.serialize_iter()
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Calendar):


### PR DESCRIPTION
In 0.8, there are some breaking changes to `str(calendar)` which can cause data loss if users update ics carelessly, so we should have at least one release that warns of this (see [here](https://github.com/ics-py/ics-py/issues/245#issuecomment-1059507609)).
As a stable 0.8 release is still somewhat in the future and we have some not-yet released fixes for version 0.7 lying around, my suggestion would be to add these warnings in a v0.7.1 release and push out all those fixes very soon (we could've actually done this in 2020 to give users even more time to prepare :see_no_evil:).

 I suggest that the implicit serialization in `Calendar.__iter__` should go in version 0.8, while the changed behaviour of `Calendar.__str__` is deferred to v0.9. For `__str__` in version 0.8, I'll keep the old serialization and the warning but also provide an easy opt-in to get the nicer future behaviour and thus suppress the warning.

@C4ptainCrunch if this sounds okay to you, could you merge this PR and then push a 0.7.1 release to PyPi?