### PR TITLE
use latest python 3.11 alpha and add pypy 3.9

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,8 +17,9 @@ jobs:
           - "3.10"
           - "pypy-3.7"
           - "pypy-3.8"
+          - "pypy-3.9"
         include:
-        - python-version: "3.11.0-alpha.3"
+        - python-version: "3.11.0-alpha - 3.11"
           experimental: true
           experimental-format: (🧪)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py37, py38, py39, py310, pypy37, pypy38, checks, docs, py311
+envlist = py37, py38, py39, py310, py311, pypy37, pypy38, pypy39, checks, docs
 
 [testenv]
 description = Run the pytest suite
@@ -57,6 +57,7 @@ python =
     3.11: py311
     pypy-3.7: pypy37
     pypy-3.8: pypy38
+    pypy-3.9: pypy39
 
 
 [pytest]


### PR DESCRIPTION
Minor changes to not have a fixed 3.11 alpha release selected and to include the latest pypy 3.8 beta, which should already be pretty stable and actually also works flawlessly.