### PR TITLE
Add test coverage for timeline (from 35% to >90%)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -117,6 +117,17 @@ docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=
 testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
 
 [[package]]
+name = "freezegun"
+version = "1.2.1"
+description = "Let your Python tests travel through time"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "hypothesis"
 version = "6.46.10"
 description = "A library for property-based testing"
@@ -615,7 +626,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [extras]
 dev = ["bump2version", "tox"]
 docs = ["sphinx"]
-test = ["pytest", "pytest-cov", "hypothesis", "tatsu", "importlib_resources", "lipsum"]
+test = ["pytest", "pytest-cov", "hypothesis", "tatsu", "importlib_resources", "lipsum", "freezegun"]
 
 [metadata]
 lock-version = "1.1"
@@ -709,6 +720,10 @@ docutils = [
 filelock = [
     {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},
     {file = "filelock-3.7.1.tar.gz", hash = "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"},
+]
+freezegun = [
+    {file = "freezegun-1.2.1-py3-none-any.whl", hash = "sha256:15103a67dfa868ad809a8f508146e396be2995172d25f927e48ce51c0bf5cb09"},
+    {file = "freezegun-1.2.1.tar.gz", hash = "sha256:b4c64efb275e6bc68dc6e771b17ffe0ff0f90b81a2a5189043550b6519926ba4"},
 ]
 hypothesis = [
     {file = "hypothesis-6.46.10-py3-none-any.whl", hash = "sha256:6f765fae7e7f1296b6d89daec4291c754d829592ec99ffaa049c5ed37a16ebad"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ hypothesis =                 { version = "^6",     optional = true }
 tatsu =                      { version = ">4.2",       optional = true }
 importlib_resources =        { version = ">=1.4",      optional = true }
 lipsum =                     { version = "^0.1.2",     optional = true }
+freezegun =                  { version = ">=1.2.1", optional = true }
 
 # extra: dev
 bump2version =               { version = "^1.0.0",     optional = true }
@@ -48,7 +49,7 @@ tox =                        { version = "^3.25",    optional = true }
 sphinx =                     { version =  "^5",        optional = true }
 
 [tool.poetry.extras]
-test = ["pytest", "pytest-cov", "hypothesis", "tatsu", "importlib_resources", "lipsum"]
+test = ["pytest", "pytest-cov", "hypothesis", "tatsu", "importlib_resources", "lipsum", "freezegun"]
 dev = ["bump2version", "tox"]
 docs = ["sphinx"]
 

--- a/tests/timeline.py
+++ b/tests/timeline.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta, date
 
 from freezegun import freeze_time

--- a/tests/timeline.py
+++ b/tests/timeline.py
@@ -14,10 +14,10 @@ def calendar() -> Calendar:
     """Fixture calendar with all day events to use in tests."""
     cal = Calendar()
     cal.events.extend([
-        Event("second", datetime(2000, 2, 1, 12, 0)),
-        Event("fourth", datetime(2000, 4, 1, 12, 0)),
-        Event("third", datetime(2000, 3, 1, 12, 0)),
-        Event("first", datetime(2000, 1, 1, 12, 0)),
+        Event("second", date(2000, 2, 1), date(2000, 2, 2)),
+        Event("fourth", date(2000, 4, 1), date(2000, 4, 2)),
+        Event("third", date(2000, 3, 1), date(2000, 3, 2)),
+        Event("first", date(2000, 1, 1), date(2000, 1, 2))
     ])
     return cal
 
@@ -67,7 +67,7 @@ def test_start_after(calendar: Calendar) -> None:
     """Test chronological iteration starting at a specific time."""
     assert [
         e.summary
-        for e in calendar.timeline.start_after(date(2000, 2, 1))
+        for e in calendar.timeline.start_after(date(2000, 1, 1))
     ] == [ "second", "third", "fourth" ]
 
 

--- a/tests/timeline.py
+++ b/tests/timeline.py
@@ -1,10 +1,13 @@
 from datetime import datetime, timedelta, date
 
+import pytest
+
 from ics import Calendar, Event
 from ics.timezone import UTC
 
 
-def make_calendar():
+@pytest.fixture
+def calendar() -> Calendar():
     """Create a test calendar for use in tests."""
     cal = Calendar()
     cal.events.extend([
@@ -16,30 +19,24 @@ def make_calendar():
     return cal
 
 
-def test_iteration():
+def test_iteration(calendar: Calendar) -> None:
     """Test chronological iteration of a timeline.""" 
-    cal = make_calendar()
-    assert [e.summary for e in cal.timeline] == [
+    assert [e.summary for e in calendar.timeline] == [
         "first", "second", "third", "fourth"
     ]
 
-def test_on():
+def test_on(calendar: Calendar) -> None:
     """Test returning events on a particualr day."""
-    cal = make_calendar()
-    timeline = cal.timeline
-    assert [e.summary for e in cal.timeline.on(date(2000, 1, 1))] == ["first"]
-    assert [e.summary for e in cal.timeline.on(date(2000, 2, 1))] == ["second"]
-    assert [e.summary for e in cal.timeline.on(datetime(2000, 3, 1, 6, 0))] == [
+    assert [e.summary for e in calendar.timeline.on(date(2000, 1, 1))] == ["first"]
+    assert [e.summary for e in calendar.timeline.on(date(2000, 2, 1))] == ["second"]
+    assert [e.summary for e in calendar.timeline.on(datetime(2000, 3, 1, 6, 0))] == [
         "third"
     ]
 
 
-def test_start_after():
+def test_start_after(calendar: Calendar) -> None:
     """Test chronological iteration starting at a specific time."""
-    cal = make_calendar()
-    timeline = cal.timeline
-
-    assert [e.summary for e in cal.timeline.start_after(date(2000, 2, 1))] == [
+    assert [e.summary for e in calendar.timeline.start_after(date(2000, 2, 1))] == [
         "second", "third", "fourth"
     ]
 

--- a/tests/timeline.py
+++ b/tests/timeline.py
@@ -1,0 +1,148 @@
+from datetime import datetime, timedelta, date
+
+from ics import Calendar, Event
+from ics.timezone import UTC
+
+
+def make_calendar():
+    """Create a test calendar for use in tests."""
+    cal = Calendar()
+    cal.events.extend([
+        Event("second", datetime(2000, 2, 1, 12, 0)),
+        Event("fourth", datetime(2000, 4, 1, 12, 0)),
+        Event("third", datetime(2000, 3, 1, 12, 0)),
+        Event("first", datetime(2000, 1, 1, 12, 0)),
+    ])
+    return cal
+
+
+def test_iteration():
+    """Test chronological iteration of a timeline.""" 
+    cal = make_calendar()
+    assert [e.summary for e in cal.timeline] == [
+        "first", "second", "third", "fourth"
+    ]
+
+def test_on():
+    """Test returning events on a particualr day."""
+    cal = make_calendar()
+    timeline = cal.timeline
+    assert [e.summary for e in cal.timeline.on(date(2000, 1, 1))] == ["first"]
+    assert [e.summary for e in cal.timeline.on(date(2000, 2, 1))] == ["second"]
+    assert [e.summary for e in cal.timeline.on(datetime(2000, 3, 1, 6, 0))] == [
+        "third"
+    ]
+
+
+def test_start_after():
+    """Test chronological iteration starting at a specific time."""
+    cal = make_calendar()
+    timeline = cal.timeline
+
+    assert [e.summary for e in cal.timeline.start_after(date(2000, 2, 1))] == [
+        "second", "third", "fourth"
+    ]
+
+
+def test_at():
+    """Test returning events at a specific time."""
+    cal = Calendar()
+    cal.events.extend([
+        Event(
+            "earlier",
+            begin=datetime(2000, 1, 1, 11, 0),
+            end=datetime(2000, 1, 1, 11, 30)
+        ),
+        Event("event",
+            begin=datetime(2000, 1, 1, 12, 0),
+            end=datetime(2000, 1, 1, 13, 0),
+        ),
+        Event("later",
+            begin=datetime(2000, 1, 2, 12, 0),
+            end=datetime(2000, 1, 2, 13, 0),
+        )
+    ])
+    assert [
+        e.summary for e in cal.timeline.at(datetime(2000, 1, 1, 11, 59))
+    ] == []
+    assert [
+        e.summary for e in cal.timeline.at(datetime(2000, 1, 1, 12, 0))
+    ] == ["event"]
+    assert [
+        e.summary for e in cal.timeline.at(datetime(2000, 1, 1, 12, 30))
+    ] == ["event"]
+    assert [
+        e.summary for e in cal.timeline.at(datetime(2000, 1, 1, 12, 59))
+    ] == ["event"]
+    assert [
+        e.summary for e in cal.timeline.at(datetime(2000, 1, 1, 13, 0))
+    ] == []
+
+
+def test_now():
+    now = datetime.now()
+
+    cal = Calendar()
+    cal.events.extend([
+        Event(
+            "before",
+            begin=(now - timedelta(days=3)),
+            end=(now - timedelta(days=2)),
+        ),
+        Event(
+            "after",
+            begin=(now + timedelta(days=2)),
+            end=(now + timedelta(days=2)),
+        ),
+        Event(
+            "now",
+            begin=(now - timedelta(days=1)),
+            end=(now + timedelta(days=1)),
+        ),
+    ])
+    assert [e.summary for e in cal.timeline.now()] == ["now"]
+
+
+def test_included():
+    cal = Calendar()
+    cal.events.extend([
+        Event(
+            "first",
+            begin=datetime(2000, 1, 1, 11, 0),
+            end=datetime(2000, 1, 1, 11, 30)
+        ),
+        Event(
+            "second",
+            begin=datetime(2000, 1, 1, 12, 0),
+            end=datetime(2000, 1, 1, 13, 0),
+        ),
+        Event(
+            "third",
+            begin=datetime(2000, 1, 2, 12, 0),
+            end=datetime(2000, 1, 2, 13, 0),
+        ),
+    ])
+    assert [
+        e.summary for e in cal.timeline.included(
+            datetime(2000, 1, 1, 10, 00),
+            datetime(2000, 1, 2, 14, 00),
+        )
+    ] == ["first", "second", "third"]
+    assert [
+        e.summary for e in cal.timeline.included(
+            datetime(2000, 1, 1, 10, 00),
+            datetime(2000, 1, 1, 14, 00),
+        )
+    ] == ["first", "second"]
+    assert [
+        e.summary for e in cal.timeline.included(
+            datetime(2000, 1, 1, 12, 00),
+            datetime(2000, 1, 2, 14, 00),
+        )
+    ] == ["second", "third"]
+    assert [
+        e.summary for e in cal.timeline.included(
+            datetime(2000, 1, 1, 12, 00),
+            datetime(2000, 1, 1, 14, 00),
+        )
+    ] == ["second"]

--- a/tests/timeline.py
+++ b/tests/timeline.py
@@ -17,8 +17,10 @@ def calendar() -> Calendar:
         Event("second", date(2000, 2, 1), date(2000, 2, 2)),
         Event("fourth", date(2000, 4, 1), date(2000, 4, 2)),
         Event("third", date(2000, 3, 1), date(2000, 3, 2)),
-        Event("first", date(2000, 1, 1), date(2000, 1, 2))
+        Event("first", date(2000, 1, 1), date(2000, 1, 2)),
     ])
+    for e in cal.events:
+        e.make_all_day()
     return cal
 
 

--- a/tests/timeline.py
+++ b/tests/timeline.py
@@ -23,8 +23,8 @@ def calendar() -> Calendar:
 
 
 @pytest.fixture
-def calendar_datetime_events() -> Calendar:
-    """Fixture calendar with events to use in tests."""
+def calendar_times() -> Calendar:
+    """Fixture calendar with datetime based events to use in tests."""
     cal = Calendar()
     cal.events.extend([
         Event(
@@ -50,20 +50,25 @@ def test_iteration(calendar: Calendar) -> None:
         "first", "second", "third", "fourth"
     ]
 
-def test_on(calendar: Calendar) -> None:
+@pytest.mark.parametrize(
+    "when,expected_events",
+    [
+        (date(2000, 1, 1), ["first"]),
+        (date(2000, 2, 1), ["second"]),
+        (datetime(2000, 3, 1, 6, 0), ["third"]),
+    ],
+)
+def test_on(calendar: Calendar, when: date | datetime, expected_events: list[str]) -> None:
     """Test returning events on a particualr day."""
-    assert [e.summary for e in calendar.timeline.on(date(2000, 1, 1))] == ["first"]
-    assert [e.summary for e in calendar.timeline.on(date(2000, 2, 1))] == ["second"]
-    assert [e.summary for e in calendar.timeline.on(datetime(2000, 3, 1, 6, 0))] == [
-        "third"
-    ]
+    assert [e.summary for e in calendar.timeline.on(when)] == expected_events
 
 
 def test_start_after(calendar: Calendar) -> None:
     """Test chronological iteration starting at a specific time."""
-    assert [e.summary for e in calendar.timeline.start_after(date(2000, 2, 1))] == [
-        "second", "third", "fourth"
-    ]
+    assert [
+        e.summary
+        for e in calendar.timeline.start_after(date(2000, 2, 1))
+    ] == [ "second", "third", "fourth" ]
 
 
 @pytest.mark.parametrize(
@@ -77,38 +82,67 @@ def test_start_after(calendar: Calendar) -> None:
         (datetime(2000, 1, 1, 13, 0), []),
     ],
 )
-def test_at(calendar_datetime_events: Calendar, at_datetime: datetime, expected_events: list[str]) -> None:
+def test_at(
+    calendar_times: Calendar,
+    at_datetime: datetime,
+    expected_events: list[str]
+) -> None:
     """Test returning events at a specific time."""
     assert [
-        e.summary for e in calendar_datetime_events.timeline.at(at_datetime)
+        e.summary for e in calendar_times.timeline.at(at_datetime)
     ] == expected_events
 
 
 @freeze_time("2000-01-01 12:30:00")
-def test_now(calendar_datetime_events: Calendar) -> None:
-    assert [e.summary for e in calendar_datetime_events.timeline.now()] == ["second"]
+def test_now(calendar_times: Calendar) -> None:
+    assert [e.summary for e in calendar_times.timeline.now()] == [
+        "second"
+    ]
 
 
 @freeze_time("2000-01-01 13:00:00")
-def test_now_no_match(calendar_datetime_events: Calendar) -> None:
-    assert [e.summary for e in calendar_datetime_events.timeline.now()] == []
+def test_now_no_match(calendar_times: Calendar) -> None:
+    assert [e.summary for e in calendar_times.timeline.now()] == []
 
 
 @freeze_time("2000-01-01 12:30:00")
-def test_today(calendar_datetime_events: Calendar) -> None:
-    assert [e.summary for e in calendar_datetime_events.timeline.today()] == ["first", "second"]
+def test_today(calendar_times: Calendar) -> None:
+    assert [e.summary for e in calendar_times.timeline.today()] == [
+        "first", "second"
+    ]
 
 
 @pytest.mark.parametrize(
     "start,end,expected_events",
     [
-        (datetime(2000, 1, 1, 10, 00), datetime(2000, 1, 2, 14, 00), ["first", "second", "third"]),
-        (datetime(2000, 1, 1, 10, 00), datetime(2000, 1, 1, 14, 00), ["first", "second"]),
-        (datetime(2000, 1, 1, 12, 00), datetime(2000, 1, 2, 14, 00), ["second", "third"]),
-        (datetime(2000, 1, 1, 12, 00), datetime(2000, 1, 1, 14, 00), ["second"]),
+        (
+            datetime(2000, 1, 1, 10, 00),
+            datetime(2000, 1, 2, 14, 00),
+            ["first", "second", "third"]
+        ),
+        (
+            datetime(2000, 1, 1, 10, 00),
+            datetime(2000, 1, 1, 14, 00),
+            ["first", "second"]
+        ),
+        (
+            datetime(2000, 1, 1, 12, 00),
+            datetime(2000, 1, 2, 14, 00),
+            ["second", "third"]
+        ),
+        (
+            datetime(2000, 1, 1, 12, 00),
+            datetime(2000, 1, 1, 14, 00),
+            ["second"]
+        ),
     ],
 )
-def test_included(calendar_datetime_events: Calendar, start: datetime, end: datetime, expected_events: list[str]) -> None:
+def test_included(
+    calendar_times: Calendar,
+    start: datetime,
+    end: datetime,
+    expected_events: list[str]
+) -> None:
     assert [
-        e.summary for e in calendar_datetime_events.timeline.included(start, end)
+        e.summary for e in calendar_times.timeline.included(start, end)
     ] == expected_events

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py37, py38, py39, py310, py311, pypy37, pypy38, pypy39, checks, docs
 
 [testenv]
 description = Run the pytest suite
+deps = freezegun>=1.2.1
 setenv =
     PYTHONDEVMODE=1
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py37, py38, py39, py310, py311, pypy37, pypy38, pypy39, checks, docs
 
 [testenv]
 description = Run the pytest suite
-deps = freezegun>=1.2.1
 setenv =
     PYTHONDEVMODE=1
 extras =


### PR DESCRIPTION
Add simple test cases for the calendar timeline to increase test coverage for timeline (from 35% to >90% according to tox codecov)

The motivation is mostly about learning the code base, and this seemed like something useful to do in the process.