### PR TITLE
Restore repr() to a small string used in the shell

### DIFF
--- a/doc/event-cmp.rst
+++ b/doc/event-cmp.rst
@@ -63,10 +63,8 @@ attributes.
 ::
 
    >>> e = ics.Event()
-   >>> e # doctest: +ELLIPSIS
-   Event(extra=Container('VEVENT', []), extra_params={}, timespan=EventTimespan(begin_time=None, end_time=None, duration=None, precision='second'), summary=None, uid='...@....org', description=None, location=None, url=None, status=None, created=None, last_modified=None, dtstamp=datetime.datetime(..., tzinfo=Timezone.from_tzid('UTC')), alarms=[], attach=[], classification=None, transparent=None, organizer=None, geo=None, attendees=[], categories=[])
-   >>> str(e)
-   '<floating Event>'
+   >>> e
+   <floating Event>
    >>> print(e.serialize())  # doctest: +ELLIPSIS,+NORMALIZE_WHITESPACE
    BEGIN:VEVENT
    UID:...@...org

--- a/doc/event.rst
+++ b/doc/event.rst
@@ -18,8 +18,8 @@ Now, we are ready to create our first event :tada:
 ::
 
    >>> e = ics.Event(begin=dt(2020, 2, 20,  20, 20))
-   >>> str(e)
-   '<floating Event begin: 2020-02-20 20:20:00 end: 2020-02-20 20:20:00>'
+   >>> e
+   <floating Event begin: 2020-02-20 20:20:00 end: 2020-02-20 20:20:00>
 
 We specified no end time or duration for the event, so the event
 defaults to ending at the same instant it begins. The event is also
@@ -32,8 +32,8 @@ the event to set the end time explicitly:
 ::
 
    >>> e.end = dt(2020, 2, 22,  20, 20)
-   >>> str(e)
-   '<floating Event begin: 2020-02-20 20:20:00 fixed end: 2020-02-22 20:20:00 duration: 2 days, 0:00:00>'
+   >>> e
+   <floating Event begin: 2020-02-20 20:20:00 fixed end: 2020-02-22 20:20:00 duration: 2 days, 0:00:00>
 
 Now, the duration of the event explicitly shows up and the end time is
 also marked as being set or “fixed” to a certain instant. If we now set
@@ -43,8 +43,8 @@ correspondingly:
 ::
 
    >>> e.duration=td(days=2)
-   >>> str(e)
-   '<floating Event begin: 2020-02-20 20:20:00 end: 2020-02-22 20:20:00 fixed duration: 2 days, 0:00:00>'
+   >>> e
+   <floating Event begin: 2020-02-20 20:20:00 end: 2020-02-22 20:20:00 fixed duration: 2 days, 0:00:00>
 
 As we now specified the duration explicitly, the duration is now fixed
 instead of the end time. This actually makes a big difference when you
@@ -54,15 +54,15 @@ now change the start time of the event:
 
    >>> e1 = ics.Event(begin=dt(2020, 2, 20,  20, 20), end=dt(2020, 2, 22,  20, 20))
    >>> e2 = ics.Event(begin=dt(2020, 2, 20,  20, 20), duration=td(days=2))
-   >>> str(e1)
-   '<floating Event begin: 2020-02-20 20:20:00 fixed end: 2020-02-22 20:20:00 duration: 2 days, 0:00:00>'
-   >>> str(e2)
-   '<floating Event begin: 2020-02-20 20:20:00 end: 2020-02-22 20:20:00 fixed duration: 2 days, 0:00:00>'
+   >>> e1
+   <floating Event begin: 2020-02-20 20:20:00 fixed end: 2020-02-22 20:20:00 duration: 2 days, 0:00:00>
+   >>> e2
+   <floating Event begin: 2020-02-20 20:20:00 end: 2020-02-22 20:20:00 fixed duration: 2 days, 0:00:00>
    >>> e1.begin = e2.begin = dt(2020, 1, 10,  10, 10)
-   >>> str(e1)
-   '<floating Event begin: 2020-01-10 10:10:00 fixed end: 2020-02-22 20:20:00 duration: 43 days, 10:10:00>'
-   >>> str(e2)
-   '<floating Event begin: 2020-01-10 10:10:00 end: 2020-01-12 10:10:00 fixed duration: 2 days, 0:00:00>'
+   >>> e1
+   <floating Event begin: 2020-01-10 10:10:00 fixed end: 2020-02-22 20:20:00 duration: 43 days, 10:10:00>
+   >>> e2
+   <floating Event begin: 2020-01-10 10:10:00 end: 2020-01-12 10:10:00 fixed duration: 2 days, 0:00:00>
 
 As we just saw, duration and end can also be passed to the constructor,
 but both are only allowed when a begin time for the event is specified,

--- a/src/ics/event.py
+++ b/src/ics/event.py
@@ -33,7 +33,7 @@ def deterministic_event_data(uid="deterministic_uid@example.org", dtstamp=dateti
         default_dtstamp_factory.reset(dtstamp_token)
 
 
-@attr.s(eq=True, order=False)
+@attr.s(eq=True, order=False, repr=False)
 class CalendarEntryAttrs(Component):
     timespan: Timespan = attr.ib()
     summary: Optional[str] = attr.ib(default=None)
@@ -165,7 +165,7 @@ class CalendarEntryAttrs(Component):
     def convert_timezone(self, tzinfo):
         self.timespan = self.timespan.convert_timezone(tzinfo)
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         name = [self.__class__.__name__]
         if self.summary:
             name.append("'%s'" % self.summary)
@@ -221,7 +221,7 @@ class CalendarEntryAttrs(Component):
         return self.timespan.is_included_in(get_timespan_if_calendar_entry(second))
 
 
-@attr.s(eq=True, order=False)  # order methods are provided by CalendarEntryAttrs
+@attr.s(eq=True, order=False, repr=False)  # order methods are provided by CalendarEntryAttrs
 class EventAttrs(CalendarEntryAttrs):
     classification: Optional[str] = attr.ib(default=None, validator=v_optional(instance_of(str)))
 

--- a/src/ics/icalendar.py
+++ b/src/ics/icalendar.py
@@ -121,12 +121,15 @@ class Calendar(CalendarAttrs):
         self.events = [e if e.all_day else normalization.normalize(e) for e in self.events]
         self.todos = [e if e.all_day else normalization.normalize(e) for e in self.todos]
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return "<Calendar with {} event{} and {} todo{}>".format(
             len(self.events),
             "" if len(self.events) == 1 else "s",
             len(self.todos),
             "" if len(self.todos) == 1 else "s")
+
+    def __str__(self):
+        return self.serialize()
 
     def __iter__(self) -> Iterator[str]:
         """Returns:
@@ -139,4 +142,4 @@ class Calendar(CalendarAttrs):
             >>> c = Calendar(); c.events.append(Event(summary="My cool event"))
             >>> open('my.ics', 'w').writelines(c)
         """
-        return iter(self.serialize().splitlines(keepends=True))
+        return iter(str(self).splitlines(keepends=True))

--- a/src/ics/timespan.py
+++ b/src/ics/timespan.py
@@ -249,7 +249,7 @@ class Timespan(object):
 
         return prefix, [self.__class__.__name__], suffix
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         prefix, name, suffix = self.get_str_segments()
         return "<%s>" % (" ".join(prefix + name + suffix))
 

--- a/src/ics/valuetype/base.py
+++ b/src/ics/valuetype/base.py
@@ -40,7 +40,7 @@ class ValueConverter(Generic[T], abc.ABC):
     def serialize(self, value: T, params: ExtraParams = EmptyParams, context: ContextDict = EmptyContext) -> str:
         ...
 
-    def __str__(self):
+    def __repr__(self):
         return "<" + self.__class__.__name__ + ">"
 
     def __hash__(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,8 +3,12 @@ import sys
 import pkg_resources
 
 import ics
+import pytest
+
+ics_path = ics.__path__[0]
 
 
+@pytest.mark.skipif("/site-packages/" not in ics_path or "/src" in ics_path, reason="ics should be imported from package not from sources for testing")
 def test_version_matches():
     dist = pkg_resources.get_distribution('ics')
     print(repr(dist), dist.__dict__, sys.path, ics.__path__)


### PR DESCRIPTION
See https://github.com/ics-py/ics-py/pull/318#issuecomment-1140403955.

Also `str()` calls `serialize()` again.