### PR TITLE
Pin mypy to a specific version to avoid breakages of main in the future

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/src/ics/converter/types/various.py
+++ b/src/ics/converter/types/various.py
@@ -39,8 +39,8 @@ class RecurrenceConverter(AttributeConverter):
         # TODO only feed dateutil the params it likes, add the rest as extra
         tzinfos = context.get(DatetimeConverterMixin.CONTEXT_KEY_AVAILABLE_TZ, {})
         rrule = dateutil.rrule.rrulestr(lines_str, tzinfos=tzinfos, compatible=True)
-        rrule._rdate = list(unique_justseen(sorted(rrule._rdate))) # type: ignore
-        rrule._exdate = list(unique_justseen(sorted(rrule._exdate))) # type: ignore
+        rrule._rdate = list(unique_justseen(sorted(rrule._rdate)))  # type: ignore
+        rrule._exdate = list(unique_justseen(sorted(rrule._exdate)))  # type: ignore
         self.set_or_append_value(component, rrule)
 
     def serialize(self, component: Component, output: Container, context: ContextDict):

--- a/src/ics/converter/types/various.py
+++ b/src/ics/converter/types/various.py
@@ -39,8 +39,8 @@ class RecurrenceConverter(AttributeConverter):
         # TODO only feed dateutil the params it likes, add the rest as extra
         tzinfos = context.get(DatetimeConverterMixin.CONTEXT_KEY_AVAILABLE_TZ, {})
         rrule = dateutil.rrule.rrulestr(lines_str, tzinfos=tzinfos, compatible=True)
-        rrule._rdate = list(unique_justseen(sorted(rrule._rdate)))
-        rrule._exdate = list(unique_justseen(sorted(rrule._exdate)))
+        rrule._rdate = list(unique_justseen(sorted(rrule._rdate))) # type: ignore
+        rrule._exdate = list(unique_justseen(sorted(rrule._exdate))) # type: ignore
         self.set_or_append_value(component, rrule)
 
     def serialize(self, component: Component, output: Container, context: ContextDict):

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 
 [testenv:mypy]
 description = Run the mypy type checks
-deps = mypy>=0.930
+deps = mypy==0.960
 commands =
     mypy -V
     mypy --non-interactive --install-types --config-file=tox.ini src/


### PR DESCRIPTION
+ ignore a hack with rrule._rdate and rrule._exdate that was failing the build