### PR TITLE
Drop python3.7 support

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,11 +11,9 @@ jobs:
       matrix:
         experimental: [false]
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
-          - "pypy-3.7"
           - "pypy-3.8"
           - "pypy-3.9"
         include:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py37, py38, py39, py310, py311, pypy37, pypy38, pypy39, checks, docs
+envlist = py38, py39, py310, py311, pypy38, pypy39, checks, docs
 
 [testenv]
 description = Run the pytest suite
@@ -50,12 +50,10 @@ commands =
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310, checks, docs
     3.11: py311
-    pypy-3.7: pypy37
     pypy-3.8: pypy38
     pypy-3.9: pypy39
 


### PR DESCRIPTION
Drop python3.7 support given python 3.8 has been out for over 2.5 years.

Issue: https://github.com/ics-py/ics-py/issues/330