### PR TITLE
Use pip and not poetry in the ReadTheDocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,3 @@
-# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
@@ -9,8 +8,6 @@ build:
   tools:
     python: "3.10"
   jobs:
-    pre_create_environment:
-      - pip install -U pip
     post_install:
       - pip install .[docs]
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,12 +10,9 @@ build:
     python: "3.10"
   jobs:
     pre_create_environment:
-      - asdf plugin add poetry
-      - asdf install poetry latest
-      - asdf global poetry latest
-      - poetry config virtualenvs.create false
+      - pip install -U pip
     post_install:
-      - poetry install -E docs
+      - pip install .[docs]
 
 sphinx:
    configuration: doc/conf.py


### PR DESCRIPTION
See https://github.com/ics-py/ics-py/issues/314#issuecomment-1143424444
Build still works https://readthedocs.org/projects/icspy/builds/17064044/