### PR TITLE
Fix date format in documentation quickstart

### DIFF
--- a/doc/howtos/quickstart.rst
+++ b/doc/howtos/quickstart.rst
@@ -44,7 +44,7 @@ Creating a new Calendar and Add Events
     c = Calendar()
     e = Event()
     e.name = "My cool event"
-    e.begin = '20140101 00:00:00'
+    e.begin = '2014-01-01 00:00:00'
     c.events.add(e)
     c.events
     # {<Event 'My cool event' begin:2014-01-01 00:00:00 end:2014-01-01 00:00:01>}


### PR DESCRIPTION
Checked the rest of the docs and did not find any more occurrences.