### PR TITLE
README: replace e.summary with e.name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Quickstart
 
  c = Calendar()
  e = Event()
- e.summary = "My cool event"
+ e.name = "My cool event"
  e.description = "A meaningful description"
  e.begin = datetime.fromisoformat("2022-06-06T12:05:23+02:00")
  e.end = datetime.fromisoformat("2022-06-06T13:05:23+02:00")


### PR DESCRIPTION
Quickstart code doesn't work properly because the non-existent property `summary` of class `Event` is used instead of `name`.