### PR TITLE
Add setuptools to test requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ test = [
     "importlib_resources >= 1.4",
     "lipsum >= 0.1.2",
     "freezegun >= 1.2.1",
+    "setuptools >= 68.2.2",
 ]
 dev = [
     "bump2version >= 1.0.0",


### PR DESCRIPTION
@C4ptainCrunch This oneline change fixes the CI failures for #395. This PR is against that branch, so if you merge this your PR should pass. Let me know if you have any questions.

`setuptools` is needed by `lipsum` and `setuptools` is no longer provided by default in Python 3.12.