### PR TITLE
Fix grammatical errors for readability

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,8 +8,8 @@ with the excellent help of `Niko Fink <https://github.com/N-Coder>`_.
 Other contributors, listed alphabetically, are:
 
 * `@aureooms <https://github.com/aureooms>`_
-* `@Azhrei <https://github.com/Azhrei>`_
 * `@azh412 <https://github.com/azh412>`_
+* `@Azhrei <https://github.com/Azhrei>`_
 * `@ConnyOnny <https://github.com/ConnyOnny>`_
 * `@danieltellez <https://github.com/danieltellez>`_
 * `@dakalamin <https://github.com/dakalamin>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,6 +9,7 @@ Other contributors, listed alphabetically, are:
 
 * `@aureooms <https://github.com/aureooms>`_
 * `@Azhrei <https://github.com/Azhrei>`_
+* `@azh412 <https://github.com/azh412>`_
 * `@ConnyOnny <https://github.com/ConnyOnny>`_
 * `@danieltellez <https://github.com/danieltellez>`_
 * `@dakalamin <https://github.com/dakalamin>`_

--- a/src/ics/icalendar.py
+++ b/src/ics/icalendar.py
@@ -34,7 +34,7 @@ class CalendarAttrs(Component):
 
 class Calendar(CalendarAttrs):
     """
-    Represents an unique RFC 5545 iCalendar.
+    Represents a unique RFC 5545 iCalendar.
 
     Attributes:
 
@@ -110,8 +110,8 @@ class Calendar(CalendarAttrs):
     @classmethod
     def parse_multiple(cls, string):
         """ "
-        Parses an input string that may contain mutiple calendars
-        and retruns a list of :class:`ics.event.Calendar`
+        Parses an input string that may contain multiple calendars
+        and returns a list of :class:`ics.event.Calendar`
         """
         containers = string_to_containers(string)
         return [cls(imports=c) for c in containers]


### PR DESCRIPTION
There were some trivial grammatical errors in `icalendar.py` which would make the documentation for `parse_multiple` harder to read. There was also an incorrect article of speech in the class comment for `Calendar`, so that was fixed.