### PR TITLE
TimezoneObservance: add an RFC-required DTSTART field

### DIFF
--- a/src/ics/timezone/__init__.py
+++ b/src/ics/timezone/__init__.py
@@ -106,7 +106,9 @@ class TimezoneObservance(Component):
 
     tzname: Optional[str] = attr.ib(default=None)
     comment: Optional[str] = attr.ib(default=None)
-
+    dtstart: Optional[datetime.datetime] = attr.ib(
+        default=datetime.datetime(1970, 1, 1)
+    )
     is_dst: ClassVar[bool] = False
 
     @property


### PR DESCRIPTION
Serializing calendars including VTIMEZONE would fail, as dateutil.tz.tzical._parse_rfc would fail validation due to the lack of DTSTART field in the timezone
observances.

This commit adds a default one set to the epoch.

Relevant RFC 5545 parts:
https://icalendar.org/iCalendar-RFC-5545/3-6-5-time-zone-component.html
https://icalendar.org/iCalendar-RFC-5545/3-8-2-4-date-time-start.html

Here is an example backtrace from before the change:
```
  File "/Users/prem/prog/ics_caldav_sync/ics_caldav_sync.py", line 141, in synchronise
    self.local_calendar.save_event((event))
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/prem/prog/ics_caldav_sync/.venv/lib/python3.13/site-packages/caldav/objects.py", line 871, in save_event
    e.save(no_overwrite=no_overwrite, no_create=no_create, obj_type="event")
    ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/prem/prog/ics_caldav_sync/.venv/lib/python3.13/site-packages/caldav/objects.py", line 2556, in save
    seqno = self.icalendar_component.pop("SEQUENCE", None)
            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/prem/prog/ics_caldav_sync/.venv/lib/python3.13/site-packages/caldav/objects.py", line 2157, in _get_icalendar_component
    if not self.icalendar_instance:
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/prem/prog/ics_caldav_sync/.venv/lib/python3.13/site-packages/caldav/objects.py", line 2670, in _get_icalendar_instance
    self.icalendar_instance = icalendar.Calendar.from_ical(
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        to_unicode(self.data)
        ^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/prem/prog/ics_caldav_sync/.venv/lib/python3.13/site-packages/icalendar/cal.py", line 394, in from_ical
    tzp.cache_timezone_component(component)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/Users/prem/prog/ics_caldav_sync/.venv/lib/python3.13/site-packages/icalendar/timezone/tzp.py", line 80, in cache_timezone_component
    self.__tz_cache[id] = timezone_component.to_tz(self)
                          ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/prem/prog/ics_caldav_sync/.venv/lib/python3.13/site-packages/icalendar/cal.py", line 861, in to_tz
    return tzp.create_timezone(self)
           ~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/prem/prog/ics_caldav_sync/.venv/lib/python3.13/site-packages/icalendar/timezone/tzp.py", line 91, in create_timezone
    return self.__provider.create_timezone(timezone_component)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/Users/prem/prog/ics_caldav_sync/.venv/lib/python3.13/site-packages/icalendar/timezone/zoneinfo.py", line 70, in create_timezone
    return self._create_timezone(tz)
           ~~~~~~~~~~~~~~~~~~~~~^^^^
  File "/Users/prem/prog/ics_caldav_sync/.venv/lib/python3.13/site-packages/icalendar/timezone/zoneinfo.py", line 75, in _create_timezone
    return tzical(file).get()
           ~~~~~~^^^^^^
  File "/Users/prem/prog/ics_caldav_sync/.venv/lib/python3.13/site-packages/dateutil/tz/tz.py", line 1279, in __init__
    self._parse_rfc(fobj.read())
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/prem/prog/ics_caldav_sync/.venv/lib/python3.13/site-packages/dateutil/tz/tz.py", line 1387, in _parse_rfc
    raise ValueError("mandatory DTSTART not found")
ValueError: mandatory DTSTART not found
```