### PR TITLE
 version 7.2: Fixed issues #411, #431

### DIFF
--- a/ics/serializers/attendee_serializer.py
+++ b/ics/serializers/attendee_serializer.py
@@ -20,7 +20,7 @@ class PersonSerializer(Serializer):
 class AttendeeSerializer(PersonSerializer):
     def serialize_rsvp(attendee: "Attendee", line: ContentLine):
         if attendee.rsvp is not None:
-            line.params["RSVP"] = [attendee.rsvp]
+            line.params["RSVP"] = [str(attendee.rsvp).upper()]
 
     def serialize_role(attendee: "Attendee", line: ContentLine):
         if attendee.role:

--- a/ics/utils.py
+++ b/ics/utils.py
@@ -177,6 +177,11 @@ def timedelta_to_duration(dt: timedelta) -> str:
         if seconds:
             res += str(seconds) + 'S'
 
+    # Avoid the following error in Thunderbird during import:
+    # JavaScript Error: invalid duration value: Not enough duration components
+    if res == 'P':
+        res = 'P0S'
+
     if dt.total_seconds() >= 0:
         return res
     else:


### PR DESCRIPTION
Issues solved for version 7.2

#431: Invalid duration value: Not enough duration components
Fixed timedelta_to_duration.

#411 RSVP parameter leads to error.
Fixed AttendeeSerializer.

